### PR TITLE
Support running with sidecar

### DIFF
--- a/api/v1/testjob_runner.go
+++ b/api/v1/testjob_runner.go
@@ -683,10 +683,7 @@ func (r *TestJobRunner) runTests(ctx context.Context, testjob TestJob, testConta
 			}
 		}
 		for _, sidecar := range sidecarExecutors {
-			sidecar := sidecar
-			go func() {
-				sidecar.Exec()
-			}()
+			sidecar.ExecAsync()
 		}
 		concurrent := testjob.Spec.DistributedTest.MaxConcurrentNumPerPod
 		testExecutorNum := len(testExecutors)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.56.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
-	github.com/goccy/kubejob v0.0.0-20201110090925-08091b67b08d
+	github.com/goccy/kubejob v0.0.0-20201119070013-04555ca36305
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.0 // indirect


### PR DESCRIPTION
`kubejob` support running job with sidecar container ( https://github.com/goccy/kubejob/pull/3 ) .
