### PR TITLE
Care injected containers at running list command

### DIFF
--- a/api/v1/testjob_runner.go
+++ b/api/v1/testjob_runner.go
@@ -661,6 +661,7 @@ func (r *TestJobRunner) runTests(ctx context.Context, testjob TestJob, testConta
 		containerName := job.Spec.Template.Spec.Containers[i].Name
 		testCommands[i].container = containerName
 	}
+	job.DisableInitContainerLog()
 	job.DisableCommandLog()
 	testLogs := []TestLog{}
 	var failedJob *kubejob.FailedJob

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.56.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
-	github.com/goccy/kubejob v0.0.0-20201119070013-04555ca36305
+	github.com/goccy/kubejob v0.0.0-20201124072221-d47966e4d5fa
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.0 // indirect


### PR DESCRIPTION
kubejob ( https://github.com/goccy/kubejob/pull/4 ) support injected container like `istio-proxy` .

Currently, `kubetest` doesn't care injected containers as sidecar at running list command.
This PR fix this problem .