### PR TITLE
Fix race condition of map for metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ deploy: test-cluster
 	kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
 
 test:
-	kubectl exec -it $(POD_NAME) -- go test -v ./ -count=1
+	kubectl exec -it $(POD_NAME) -- go test -race -v ./ -count=1
 
 # Build manager binary
 manager: generate fmt vet


### PR DESCRIPTION
Since `job.Spec.Template.ObjectMeta.Labels` is `map[string]string` type, it shared between all test groups and the each test groups access the map concurrently.
So, these access may break map data, and if labels data broken, occur unexpectedly behavior .
