### PR TITLE
Bump up kubejob version to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.56.0 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
-	github.com/goccy/kubejob v0.1.0
+	github.com/goccy/kubejob v0.1.2
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.0 // indirect


### PR DESCRIPTION
### Features

- Support gracefully termination
- Fix condition of retrying

### Changes

https://github.com/goccy/kubejob/compare/v0.1.0...v0.1.2

### FYI

If `remotecommand.Stream()` returns error by failure of test , `error` instance is `exec.CodeExitError` ( https://github.com/kubernetes/client-go/blob/master/tools/remotecommand/v4.go#L106-L108 ) .
`exec.CodeExitError` implements `ExitError` interface ( See https://github.com/kubernetes/client-go/blob/master/util/exec/exec.go#L22 ) .

