### PR TITLE
Avoid sharing the cloned directory for distributed test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,12 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v2
-    - name: Setup kind
+    - name: setup kind
       run: |
         make deploy
+    - name: wait for available
+      run: |
+        make wait
     - name: Run test
       run: |
         timeout 800 make test

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(BIN):
 	@mkdir -p $(BIN)
 
 KIND := $(BIN)/kind
-KIND_VERSION := v0.8.1
+KIND_VERSION := v0.11.0
 $(KIND): | $(BIN)
 	@curl -sSLo $(KIND) "https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(UNAME_OS)-amd64"
 	@chmod +x $(KIND)
@@ -44,7 +44,18 @@ delete-cluster: $(KIND)
 
 deploy: test-cluster
 	kubectl apply -f testdata/config/manifest.yaml
-	kubectl apply -f https://docs.projectcalico.org/v3.8/manifests/calico.yaml
+
+wait:
+	{ \
+	set -e ;\
+	while true; do \
+		POD_NAME=$$(KUBECONFIG=$(KUBECONFIG) kubectl get pod | grep Running | grep kubetest-deployment | awk '{print $$1}'); \
+		if [ "$$POD_NAME" != "" ]; then \
+			exit 0; \
+		fi; \
+		sleep 1; \
+	done; \
+	}
 
 test:
 	{ \

--- a/api/v1/testjob_api.go
+++ b/api/v1/testjob_api.go
@@ -346,11 +346,17 @@ func (j TestJob) testContainers(extraContainers ...apiv1.Container) []apiv1.Cont
 			continue
 		}
 		container.VolumeMounts = append(container.VolumeMounts, j.archiveVolumeMount())
+		if j.Spec.DistributedTest == nil {
+			container.VolumeMounts = append(container.VolumeMounts, j.workspaceVolumeMount())
+		}
 		testContainers = append(testContainers, container)
 	}
 	for _, container := range extraContainers {
 		container := container
 		container.VolumeMounts = append(container.VolumeMounts, j.archiveVolumeMount())
+		if j.Spec.DistributedTest == nil {
+			container.VolumeMounts = append(container.VolumeMounts, j.workspaceVolumeMount())
+		}
 		testContainers = append(testContainers, container)
 	}
 	return testContainers
@@ -510,7 +516,7 @@ func (j TestJob) createTestJobTemplate(token string, tests []string) (apiv1.PodT
 		})
 		template.Spec.InitContainers = append(template.Spec.InitContainers, cacheContainer)
 	}
-	if j.enabledCheckout() {
+	if j.Spec.DistributedTest != nil && j.enabledCheckout() {
 		template.Spec.InitContainers = append(template.Spec.InitContainers, j.packRepoContainer())
 	}
 	return template, nil

--- a/api/v1/testjob_api.go
+++ b/api/v1/testjob_api.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	sharedVolumeName  = "repo"
+	repoVolumeName    = "repo"
+	archiveVolumeName = "archive"
 	oauthTokenEnv     = "OAUTH_TOKEN"
 	defaultGitImage   = "alpine/git"
 	defaultBranch     = "master"
@@ -26,7 +27,9 @@ const (
 )
 
 var (
-	defaultVolumeMountPath = filepath.Join("/", "git", "workspace")
+	defaultWorkspacePath = filepath.Join("/", "git", "workspace")
+	repoMountPath        = filepath.Join("/", "git", "repo")
+	archiveMountPath     = filepath.Join("/", "git", "archive")
 )
 
 func (j TestJob) existsPrepareSteps() bool {
@@ -52,7 +55,7 @@ func (j TestJob) prepareWorkingDir(step int) string {
 	if dir != "" {
 		return dir
 	}
-	return j.volumeMountPath()
+	return j.workspacePath()
 }
 
 func (j TestJob) prepareEnv(step int) []apiv1.EnvVar {
@@ -132,7 +135,7 @@ func (j TestJob) workingDir(c apiv1.Container) string {
 	if c.WorkingDir != "" {
 		return c.WorkingDir
 	}
-	return j.volumeMountPath()
+	return j.workspacePath()
 }
 
 func (j TestJob) enabledCheckout() bool {
@@ -143,27 +146,50 @@ func (j TestJob) enabledCheckout() bool {
 	return true
 }
 
-func (j TestJob) volumeMountPath() string {
+func (j TestJob) workspacePath() string {
 	checkoutDir := j.checkoutDir()
 	if checkoutDir != "" {
 		return checkoutDir
 	}
-	return defaultVolumeMountPath
+	return defaultWorkspacePath
 }
 
-func (j TestJob) sharedVolume() apiv1.Volume {
+func (j TestJob) repoVolume() apiv1.Volume {
 	return apiv1.Volume{
-		Name: sharedVolumeName,
+		Name: repoVolumeName,
 		VolumeSource: apiv1.VolumeSource{
 			EmptyDir: &apiv1.EmptyDirVolumeSource{},
 		},
 	}
 }
 
-func (j TestJob) sharedVolumeMount() apiv1.VolumeMount {
+func (j TestJob) workspaceVolumeMount() apiv1.VolumeMount {
 	return apiv1.VolumeMount{
-		Name:      sharedVolumeName,
-		MountPath: j.volumeMountPath(),
+		Name:      repoVolumeName,
+		MountPath: j.workspacePath(),
+	}
+}
+
+func (j TestJob) repoVolumeMount() apiv1.VolumeMount {
+	return apiv1.VolumeMount{
+		Name:      repoVolumeName,
+		MountPath: repoMountPath,
+	}
+}
+
+func (j TestJob) archiveVolume() apiv1.Volume {
+	return apiv1.Volume{
+		Name: archiveVolumeName,
+		VolumeSource: apiv1.VolumeSource{
+			EmptyDir: &apiv1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+func (j TestJob) archiveVolumeMount() apiv1.VolumeMount {
+	return apiv1.VolumeMount{
+		Name:      archiveVolumeName,
+		MountPath: archiveMountPath,
 	}
 }
 
@@ -175,12 +201,11 @@ func (j TestJob) gitCloneURL(token string) string {
 }
 
 func (j TestJob) gitCloneCommand(cloneURL string) ([]string, []string) {
-	mountPath := j.volumeMountPath()
 	branch := j.branch()
 	if branch != "" {
-		return []string{"git"}, []string{"clone", "-b", branch, cloneURL, mountPath}
+		return []string{"git"}, []string{"clone", "-b", branch, cloneURL, j.workspacePath()}
 	}
-	return []string{"git"}, []string{"clone", cloneURL, mountPath}
+	return []string{"git"}, []string{"clone", cloneURL, j.workspacePath()}
 }
 
 func (j TestJob) gitCloneContainer(token string) apiv1.Container {
@@ -191,7 +216,7 @@ func (j TestJob) gitCloneContainer(token string) apiv1.Container {
 		Command:      cmd,
 		Args:         args,
 		Env:          []apiv1.EnvVar{{Name: oauthTokenEnv, Value: token}},
-		VolumeMounts: []apiv1.VolumeMount{j.sharedVolumeMount()},
+		VolumeMounts: []apiv1.VolumeMount{j.workspaceVolumeMount()},
 	}
 }
 
@@ -199,10 +224,10 @@ func (j TestJob) gitSwitchContainer() apiv1.Container {
 	return apiv1.Container{
 		Name:         "kubetest-init-switch",
 		Image:        j.gitImage(),
-		WorkingDir:   j.volumeMountPath(),
+		WorkingDir:   j.workspacePath(),
 		Command:      []string{"git"},
 		Args:         []string{"checkout", "--detach", j.rev()},
-		VolumeMounts: []apiv1.VolumeMount{j.sharedVolumeMount()},
+		VolumeMounts: []apiv1.VolumeMount{j.workspaceVolumeMount()},
 	}
 }
 
@@ -210,10 +235,10 @@ func (j TestJob) gitConfigUserEmailContainer() apiv1.Container {
 	return apiv1.Container{
 		Name:         "kubetest-init-git-config-user-email",
 		Image:        j.gitImage(),
-		WorkingDir:   j.volumeMountPath(),
+		WorkingDir:   j.workspacePath(),
 		Command:      []string{"git"},
 		Args:         []string{"config", "user.email", "anonymous@kubetest.com"},
-		VolumeMounts: []apiv1.VolumeMount{j.sharedVolumeMount()},
+		VolumeMounts: []apiv1.VolumeMount{j.workspaceVolumeMount()},
 	}
 }
 
@@ -221,10 +246,10 @@ func (j TestJob) gitConfigUserNameContainer() apiv1.Container {
 	return apiv1.Container{
 		Name:         "kubetest-init-git-config-user-name",
 		Image:        j.gitImage(),
-		WorkingDir:   j.volumeMountPath(),
+		WorkingDir:   j.workspacePath(),
 		Command:      []string{"git"},
 		Args:         []string{"config", "user.name", "anonymous"},
-		VolumeMounts: []apiv1.VolumeMount{j.sharedVolumeMount()},
+		VolumeMounts: []apiv1.VolumeMount{j.workspaceVolumeMount()},
 	}
 }
 
@@ -232,10 +257,40 @@ func (j TestJob) gitMergeContainer() apiv1.Container {
 	return apiv1.Container{
 		Name:         "kubetest-init-merge",
 		Image:        j.gitImage(),
-		WorkingDir:   j.volumeMountPath(),
+		WorkingDir:   j.workspacePath(),
 		Command:      []string{"git"},
 		Args:         []string{"pull", "origin", j.baseBranch()},
-		VolumeMounts: []apiv1.VolumeMount{j.sharedVolumeMount()},
+		VolumeMounts: []apiv1.VolumeMount{j.workspaceVolumeMount()},
+	}
+}
+
+func (j TestJob) packRepoContainer() apiv1.Container {
+	base, target := filepath.Split(j.workspacePath())
+	return apiv1.Container{
+		Name:       "kubetest-pack-repo",
+		Image:      j.gitImage(),
+		WorkingDir: base,
+		Command:    []string{"tar"},
+		Args: []string{
+			"-czf",
+			filepath.Join(archiveMountPath, "repo.tar.gz"),
+			target,
+		},
+		VolumeMounts: []apiv1.VolumeMount{
+			j.workspaceVolumeMount(),
+			j.archiveVolumeMount(),
+		},
+	}
+}
+
+func (j TestJob) unpackRepoCommand() []string {
+	base, _ := filepath.Split(j.workspacePath())
+	return []string{
+		"tar",
+		"-zxvf",
+		filepath.Join(archiveMountPath, "repo.tar.gz"),
+		"-C",
+		base,
 	}
 }
 
@@ -290,12 +345,12 @@ func (j TestJob) testContainers(extraContainers ...apiv1.Container) []apiv1.Cont
 			// skip default test container
 			continue
 		}
-		container.VolumeMounts = append(container.VolumeMounts, j.sharedVolumeMount())
+		container.VolumeMounts = append(container.VolumeMounts, j.archiveVolumeMount())
 		testContainers = append(testContainers, container)
 	}
 	for _, container := range extraContainers {
 		container := container
-		container.VolumeMounts = append(container.VolumeMounts, j.sharedVolumeMount())
+		container.VolumeMounts = append(container.VolumeMounts, j.archiveVolumeMount())
 		testContainers = append(testContainers, container)
 	}
 	return testContainers
@@ -331,7 +386,11 @@ func (j TestJob) createJobTemplate(token string, extraContainers ...apiv1.Contai
 	template := j.Spec.Template // copy template
 	template.Spec.InitContainers = j.testInitContainers(token)
 	template.Spec.Containers = j.testContainers(extraContainers...)
-	template.Spec.Volumes = append(template.Spec.Volumes, j.sharedVolume())
+	template.Spec.Volumes = append(
+		template.Spec.Volumes,
+		j.repoVolume(),
+		j.archiveVolume(),
+	)
 
 	newLabels := map[string]string{}
 	for k, v := range template.ObjectMeta.Labels {
@@ -362,7 +421,7 @@ func (j TestJob) createPrepareJobTemplate(token string) (apiv1.PodTemplateSpec, 
 			Args:       args,
 			WorkingDir: j.prepareWorkingDir(stepIdx),
 			VolumeMounts: []apiv1.VolumeMount{
-				j.sharedVolumeMount(),
+				j.workspaceVolumeMount(),
 			},
 			Env: j.prepareEnv(stepIdx),
 		})
@@ -372,7 +431,8 @@ func (j TestJob) createPrepareJobTemplate(token string) (apiv1.PodTemplateSpec, 
 	return apiv1.PodTemplateSpec{
 		Spec: apiv1.PodSpec{
 			Volumes: []apiv1.Volume{
-				j.sharedVolume(),
+				j.repoVolume(),
+				j.archiveVolume(),
 			},
 			InitContainers:   initContainers,
 			Containers:       []apiv1.Container{lastContainer},
@@ -392,6 +452,9 @@ func (j TestJob) createListJobTemplate(token string) (apiv1.PodTemplateSpec, err
 	c.Args = listSpec.Args
 	c.WorkingDir = j.workingDir(c)
 	template := j.createJobTemplate(token, c)
+	if j.enabledCheckout() {
+		template.Spec.InitContainers = append(template.Spec.InitContainers, j.packRepoContainer())
+	}
 	template.ObjectMeta.Labels[listJobLabel] = fmt.Sprint(true)
 	return template, nil
 }
@@ -426,7 +489,7 @@ func (j TestJob) createTestJobTemplate(token string, tests []string) (apiv1.PodT
 	}
 	for _, cache := range j.Spec.DistributedTest.Cache {
 		cmd, args := j.escapedCommand(cache.Command)
-		volumeMounts := append(c.VolumeMounts, j.sharedVolumeMount(), apiv1.VolumeMount{
+		volumeMounts := append(c.VolumeMounts, j.workspaceVolumeMount(), apiv1.VolumeMount{
 			Name:      cache.Name,
 			MountPath: cache.Path,
 		})
@@ -446,6 +509,9 @@ func (j TestJob) createTestJobTemplate(token string, tests []string) (apiv1.PodT
 			},
 		})
 		template.Spec.InitContainers = append(template.Spec.InitContainers, cacheContainer)
+	}
+	if j.enabledCheckout() {
+		template.Spec.InitContainers = append(template.Spec.InitContainers, j.packRepoContainer())
 	}
 	return template, nil
 }

--- a/api/v1/testjob_copyfile.go
+++ b/api/v1/testjob_copyfile.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -10,13 +11,52 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/goccy/kubejob"
+	"github.com/lestrrat-go/backoff"
 	"golang.org/x/xerrors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/remotecommand"
+	executil "k8s.io/client-go/util/exec"
 	"k8s.io/kubectl/pkg/scheme"
 )
+
+var (
+	copyMaxRetryCount = 8
+)
+
+func (r *TestJobRunner) copyTextFileWithRetry(executor *kubejob.JobExecutor, src, outputDir string) error {
+	var err error
+	policy := backoff.NewExponential(
+		backoff.WithInterval(1*time.Second),
+		backoff.WithMaxRetries(copyMaxRetryCount),
+	)
+	b, cancel := policy.Start(context.Background())
+	defer cancel()
+
+	retryCount := 0
+	for backoff.Continue(b) {
+		err = r.copyTextFile(executor, src, outputDir)
+		if err != nil {
+			if _, ok := err.(executil.ExitError); ok {
+				break
+			}
+			// cannot connect to Pod. retry....
+			r.logPrinter.DebugLog(fmt.Sprintf(
+				"[WARN] failed to copy at %s (%s). retry: %d/%d",
+				executor.Container.Name,
+				err,
+				retryCount,
+				copyMaxRetryCount,
+			))
+			retryCount++
+			continue
+		}
+		break
+	}
+	return err
+}
 
 func (r *TestJobRunner) copyTextFile(executor *kubejob.JobExecutor, src, outputDir string) (e error) {
 	pod := executor.Pod

--- a/api/v1/testjob_copyfile.go
+++ b/api/v1/testjob_copyfile.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	copyMaxRetryCount = 8
+	copyMaxRetryCount = 5
 )
 
 func (r *TestJobRunner) copyTextFileWithRetry(executor *kubejob.JobExecutor, src, outputDir string) error {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.14
 
 require (
 	github.com/go-logr/logr v0.4.0
-	github.com/goccy/kubejob v0.2.4
+	github.com/goccy/kubejob v0.2.5
 	github.com/jessevdk/go-flags v1.5.0
+	github.com/lestrrat-go/backoff v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0
 	github.com/rs/xid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,12 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/goccy/kubejob v0.2.4 h1:LVQoIlDlM/Iu1s3TIz5Tr8nBip0wTiNM99dK8u9Plqc=
 github.com/goccy/kubejob v0.2.4/go.mod h1:u8pBGV3XWjnW4k38Q6rXtYLrCCvFkaL2dvzj+8/pJZI=
+github.com/goccy/kubejob v0.2.5-0.20210707094047-a96dbcd38451 h1:fnunlB06vWtScpjf7DkYS+G51h9yxNJ3gavCxkO3NH0=
+github.com/goccy/kubejob v0.2.5-0.20210707094047-a96dbcd38451/go.mod h1:u8pBGV3XWjnW4k38Q6rXtYLrCCvFkaL2dvzj+8/pJZI=
+github.com/goccy/kubejob v0.2.5-0.20210708031708-23205f758f98 h1:W/k2efZBVfH1X3kcy7fgj/YO6S4cLvw9zGoQZe9F6K0=
+github.com/goccy/kubejob v0.2.5-0.20210708031708-23205f758f98/go.mod h1:u8pBGV3XWjnW4k38Q6rXtYLrCCvFkaL2dvzj+8/pJZI=
+github.com/goccy/kubejob v0.2.5 h1:9EgswkTcH1XBQbMR9JsMpDRRW6uK5KrCuMTs3ao47pM=
+github.com/goccy/kubejob v0.2.5/go.mod h1:u8pBGV3XWjnW4k38Q6rXtYLrCCvFkaL2dvzj+8/pJZI=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/testdata/config/cluster.yaml
+++ b/testdata/config/cluster.yaml
@@ -6,6 +6,3 @@ nodes:
   extraMounts:
   - hostPath: .
     containerPath: /home/kubetest
-networking:
-  disableDefaultCNI: true # disable kindnet
-  podSubnet: 192.168.0.0/16 # set to Calico's default subnet

--- a/testdata/config/manifest.yaml
+++ b/testdata/config/manifest.yaml
@@ -75,7 +75,7 @@ spec:
       serviceAccountName: kubetest
       containers:
         - name: kubetest
-          image: golang:1.15
+          image: golang:1.16.5-buster
           workingDir: /go/src/kubetest
           command:
             - tail


### PR DESCRIPTION
Currently, when running a distributed test, each container shares the directory where the git clone was done.
In this case, conflicts will occur if the test artifacts are outputted directly to the shared directory.
So, we should avoid sharing directory between containers.
