### PR TITLE
Fix command executor

### DIFF
--- a/api/v1/kubetest_test.go
+++ b/api/v1/kubetest_test.go
@@ -254,6 +254,53 @@ spec:
 			t.Fatalf("%+v", err)
 		}
 	})
+	t.Run("use sh -c", func(t *testing.T) {
+		t.Parallel()
+		crd := `
+apiVersion: kubetest.io/v1
+kind: TestJob
+metadata:
+  name: testjob
+  namespace: default
+spec:
+  git:
+    repo: github.com/goccy/kubetest
+    branch: master
+    checkoutDir: /go/src/kubetest
+  template:
+    spec:
+      containers:
+        - name: test
+          image: golang:1.15
+          command:
+            - sh
+            - -c
+          args:
+            - |
+              set -eu
+              echo $TEST
+          workingDir: /go/src/kubetest/_examples
+  distributedTest:
+    containerName: test
+    maxContainersPerPod: 18
+    maxConcurrentNumPerPod: 2
+    list:
+      names:
+        - TEST_A
+        - TEST_B
+`
+		runner, err := kubetestv1.NewTestJobRunner(cfg)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		var job kubetestv1.TestJob
+		if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crd), 1024).Decode(&job); err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if err := runner.Run(context.Background(), job); err != nil {
+			t.Fatalf("%+v", err)
+		}
+	})
 	t.Run("merge base branch", func(t *testing.T) {
 		t.Parallel()
 		crd := `

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/go-logr/logr v0.4.0
-	github.com/goccy/kubejob v0.2.6
+	github.com/goccy/kubejob v0.2.7
 	github.com/google/go-github/v29 v29.0.2
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/lestrrat-go/backoff v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/go-logr/logr v0.4.0
-	github.com/goccy/kubejob v0.2.7
+	github.com/goccy/kubejob v0.2.8
 	github.com/google/go-github/v29 v29.0.2
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/lestrrat-go/backoff v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
-github.com/goccy/kubejob v0.2.7 h1:ZEEgkbFGAHq6d1fWPKf/nFQY0VCv+1GsHywNBq0u4dA=
-github.com/goccy/kubejob v0.2.7/go.mod h1:u8pBGV3XWjnW4k38Q6rXtYLrCCvFkaL2dvzj+8/pJZI=
+github.com/goccy/kubejob v0.2.8 h1:ncWig84Tu2kb9irzarwar1xCgj6o3zYpnEXdpp6J49M=
+github.com/goccy/kubejob v0.2.8/go.mod h1:u8pBGV3XWjnW4k38Q6rXtYLrCCvFkaL2dvzj+8/pJZI=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
-github.com/goccy/kubejob v0.2.6 h1:vf0YNzUjnM/n04RyGnwsyplNanNULnnK7x9cnZmu5+Q=
-github.com/goccy/kubejob v0.2.6/go.mod h1:u8pBGV3XWjnW4k38Q6rXtYLrCCvFkaL2dvzj+8/pJZI=
+github.com/goccy/kubejob v0.2.7 h1:ZEEgkbFGAHq6d1fWPKf/nFQY0VCv+1GsHywNBq0u4dA=
+github.com/goccy/kubejob v0.2.7/go.mod h1:u8pBGV3XWjnW4k38Q6rXtYLrCCvFkaL2dvzj+8/pJZI=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=


### PR DESCRIPTION
Update kubejob version to v0.2.8 to support `sh -c` style command .

### Changes

https://github.com/goccy/kubejob/compare/v0.2.6...v0.2.8