### PR TITLE
Support ClonedPath field for RepositorySpec

### DIFF
--- a/api/v1/repo_test.go
+++ b/api/v1/repo_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"testing"
+
+	"github.com/go-git/go-git/v5"
 )
 
 func TestRepositoryManager(t *testing.T) {
@@ -62,5 +64,43 @@ func TestRepositoryManager(t *testing.T) {
 			t.Fatal("failed to clone repository with revision")
 		}
 		t.Logf("checkout by revision. archive path: %s", path)
+	})
+	t.Run("reuse cloned directory", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "repo")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := os.RemoveAll(dir); err != nil {
+				t.Fatal(err)
+			}
+		}()
+		if _, err := git.PlainCloneContext(context.Background(), dir, false, &git.CloneOptions{
+			URL: "https://github.com/goccy/kubetest.git",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		mgr := NewRepositoryManager([]RepositorySpec{
+			{
+				Name:  "test",
+				Value: Repository{ClonedPath: dir},
+			},
+		}, new(TokenManager))
+		defer func() {
+			if err := mgr.Cleanup(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+		if err := mgr.CloneAll(WithLogger(context.Background(), NewLogger(os.Stdout, LogLevelDebug))); err != nil {
+			t.Fatal(err)
+		}
+		path, err := mgr.ArchivePathByRepoName("test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if path == "" {
+			t.Fatal("failed to get archive path")
+		}
+		t.Logf("archive path: %s", path)
 	})
 }

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -53,6 +53,10 @@ type Repository struct {
 	Token string `json:"token,omitempty"`
 	// Merge base branch
 	Merge *MergeSpec `json:"merge,omitempty"`
+	// ClonedPath specify the clone destination directory for repository.
+	// If the target repository has already been cloned and the directory is not empty,
+	// it will be reused ( doesn't clone ).
+	ClonedPath string `json:"clonedPath,omitempty"`
 }
 
 // MergeSpec describes the specification of merge behavior.

--- a/api/v1/util.go
+++ b/api/v1/util.go
@@ -12,6 +12,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func existsDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
 func getMainContainerFromTmpl(tmpl TestJobTemplateSpec) (corev1.Container, error) {
 	if tmpl.Main != "" {
 		for _, container := range tmpl.Spec.Containers {


### PR DESCRIPTION
If you have already cloned the test repository, you can skip the clone by specifying that directory.

```yaml
spec:
  repos:
    - name: test-repo
      value:
        clonedPath: /path/to/repo
```