### PR TITLE
Add a new token source ( filePath )

### DIFF
--- a/api/v1/token.go
+++ b/api/v1/token.go
@@ -81,6 +81,8 @@ func (c *TokenClient) AccessToken(ctx context.Context, token TokenSource) (strin
 		return c.tokenFromGitHubApp(ctx, token.GitHubApp)
 	case token.GitHubToken != nil:
 		return c.tokenFromGitHubToken(ctx, token.GitHubToken)
+	case token.FilePath != nil:
+		return c.tokenFromFilePath(ctx, token.FilePath)
 	}
 	return "", nil
 }
@@ -118,6 +120,14 @@ func (c *TokenClient) tokenFromGitHubApp(ctx context.Context, source *GitHubAppT
 		return "", fmt.Errorf("kubetset: failed to get token from github app params: %w", err)
 	}
 	return token, nil
+}
+
+func (c *TokenClient) tokenFromFilePath(ctx context.Context, source *string) (string, error) {
+	data, err := os.ReadFile(*source)
+	if err != nil {
+		return "", fmt.Errorf("kubetest: failed to get token from file path: %w", err)
+	}
+	return string(data), nil
 }
 
 func (c *TokenClient) tokenFromGitHubAppWithParam(ctx context.Context, appID, installationID int64, org string, privateKey []byte) (string, error) {

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -80,6 +80,7 @@ type TokenSpec struct {
 type TokenSource struct {
 	GitHubApp   *GitHubAppTokenSource `json:"githubApp,omitempty"`
 	GitHubToken *GitHubTokenSource    `json:"githubToken,omitempty"`
+	FilePath    *string               `json:"filePath,omitempty"`
 }
 
 // GitHubAppTokenSource describes the specification of github app based token.

--- a/api/v1/validator.go
+++ b/api/v1/validator.go
@@ -86,17 +86,29 @@ func (v *Validator) ValidateToken(token TokenSpec) error {
 	if token.Name == "" {
 		return fmt.Errorf("kubetest: token name must be specified")
 	}
-	if token.Value.GitHubApp == nil && token.Value.GitHubToken == nil {
-		return fmt.Errorf("kubetest: githubApp or githubToken must be specified")
+	var foundSource int
+	if token.Value.GitHubApp != nil {
+		foundSource++
 	}
-	if token.Value.GitHubApp != nil && token.Value.GitHubToken != nil {
-		return fmt.Errorf("kubetest: only one of githubApp or githubToken needs to be specified")
+	if token.Value.GitHubToken != nil {
+		foundSource++
+	}
+	if token.Value.FilePath != nil {
+		foundSource++
+	}
+	if foundSource == 0 {
+		return fmt.Errorf("kubetest: githubApp or githubToken or filePath must be specified")
+	}
+	if foundSource > 1 {
+		return fmt.Errorf("kubetest: only one of githubApp or githubToken or filePath needs to be specified")
 	}
 	switch {
 	case token.Value.GitHubApp != nil:
 		return v.ValidateGitHubAppTokenSource(token.Value.GitHubApp)
 	case token.Value.GitHubToken != nil:
 		return v.ValidateGitHubTokenSource(token.Value.GitHubToken)
+	case token.Value.FilePath != nil:
+		return v.ValidateFilePathTokenSource(token.Value.FilePath)
 	}
 	return nil
 }
@@ -120,6 +132,13 @@ func (v *Validator) ValidateGitHubTokenSource(source *GitHubTokenSource) error {
 	}
 	if source.Key == "" {
 		return fmt.Errorf("kubetest: githubToken.key must be specified")
+	}
+	return nil
+}
+
+func (v *Validator) ValidateFilePathTokenSource(source *string) error {
+	if source == nil || *source == "" {
+		return fmt.Errorf("kubetest: filePath must be not empty string")
 	}
 	return nil
 }


### PR DESCRIPTION
If the token is already mounted on a container running kubetest, you can use it