### PR TITLE
Support termination log

### DIFF
--- a/api/v1/job.go
+++ b/api/v1/job.go
@@ -30,6 +30,7 @@ type Job interface {
 type JobExecutor interface {
 	Output(context.Context) ([]byte, error)
 	ExecAsync(context.Context)
+	TerminationLog(context.Context, string) error
 	Stop(context.Context) error
 	CopyFrom(context.Context, string, string) error
 	CopyTo(context.Context, string, string) error
@@ -140,6 +141,10 @@ func (e *kubernetesJobExecutor) Output(_ context.Context) ([]byte, error) {
 
 func (e *kubernetesJobExecutor) ExecAsync(_ context.Context) {
 	e.exec.ExecAsync()
+}
+
+func (e *kubernetesJobExecutor) TerminationLog(_ context.Context, log string) error {
+	return e.exec.TerminationLog(log)
 }
 
 func (e *kubernetesJobExecutor) Stop(_ context.Context) error {
@@ -287,6 +292,10 @@ func (e *localJobExecutor) ExecAsync(_ context.Context) {
 	}()
 }
 
+func (e *localJobExecutor) TerminationLog(_ context.Context, _ string) error {
+	return nil
+}
+
 func (e *localJobExecutor) Stop(_ context.Context) error {
 	return nil
 }
@@ -356,8 +365,9 @@ func (e *dryRunJobExecutor) Output(_ context.Context) ([]byte, error) {
 	return []byte("( dry running .... )"), nil
 }
 
-func (e *dryRunJobExecutor) ExecAsync(_ context.Context)  {}
-func (e *dryRunJobExecutor) Stop(_ context.Context) error { return nil }
+func (e *dryRunJobExecutor) ExecAsync(_ context.Context)                      {}
+func (e *dryRunJobExecutor) TerminationLog(_ context.Context, _ string) error { return nil }
+func (e *dryRunJobExecutor) Stop(_ context.Context) error                     { return nil }
 func (e *dryRunJobExecutor) CopyFrom(ctx context.Context, src string, dst string) error {
 	LoggerFromContext(ctx).Debug("copy from %s on container to %s on local", src, dst)
 	return nil

--- a/api/v1/subtask.go
+++ b/api/v1/subtask.go
@@ -46,13 +46,17 @@ func (t *SubTask) outputError(logGroup Logger, baseErr error) {
 	}
 }
 
+const (
+	terminationLog = "kubetest task is completed"
+)
+
 func (t *SubTask) Run(ctx context.Context) *SubTaskResult {
 	logger := LoggerFromContext(ctx)
 	logGroup := logger.Group()
 	ctx = WithLogger(ctx, logGroup)
 	defer func() {
-		if err := t.exec.Stop(ctx); err != nil {
-			logGroup.Warn("failed to stop %s", err)
+		if err := t.exec.TerminationLog(ctx, terminationLog); err != nil {
+			logGroup.Warn("failed to send termination log: %s", err.Error())
 		}
 		logger.LogGroup(logGroup)
 		if t.OnFinish != nil {

--- a/api/v1/task.go
+++ b/api/v1/task.go
@@ -105,12 +105,13 @@ func (t *Task) run(ctx context.Context) (*TaskResult, error) {
 			result.add(group)
 			return nil
 		}
-		for _, subTaskGroup := range t.strategyKey.SubTaskScheduler.Schedule(subTasks) {
-			group, err := subTaskGroup.Run(ctx)
+		subTaskGroups := t.strategyKey.SubTaskScheduler.Schedule(subTasks)
+		for _, subTaskGroup := range subTaskGroups {
+			rg, err := subTaskGroup.Run(ctx)
 			if err != nil {
 				return err
 			}
-			result.add(group)
+			result.add(rg)
 		}
 		return nil
 	}); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.3
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
-	github.com/goccy/kubejob v0.2.13
+	github.com/goccy/kubejob v0.2.14
 	github.com/google/go-github/v29 v29.0.2
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/lestrrat-go/backoff v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/goccy/kubejob v0.2.13 h1:b6lr1BjPvmedoBFrWT4F9Eh9eNhWAVe3vLcBDgdBRo8=
-github.com/goccy/kubejob v0.2.13/go.mod h1:VRKVeIFQ3Fm+b7w9kq3J6a0A7+hJxEK8KDp7uMFDBAc=
+github.com/goccy/kubejob v0.2.14 h1:qk7s0OGU2l9XjQSDRHPLPxxun2l9Od/FmgtQvh6q9yA=
+github.com/goccy/kubejob v0.2.14/go.mod h1:VRKVeIFQ3Fm+b7w9kq3J6a0A7+hJxEK8KDp7uMFDBAc=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=


### PR DESCRIPTION
## What

Currently, we call Stop as soon as the task finishes and terminate Container. If another Container is processing or waiting for a task, the Pod's status will be NotReady, which is not desirable as a normal case state.
Therefore, changed logic that it finishes at the same time after the tasks in all containers are finished. This makes it difficult to identify the container that was terminated while the Pod was running, so we now output the termination-log. This will tell you if it's finished by looking at the logs on that container.

( default termination-log's path is `/dev/termination-log` )

### Changes

- Update kubejob version to v0.2.14
- Use `t.exec.TerminationLog` instead of `t.exec.Stop` 

### kubejob's Release Summary

https://github.com/goccy/kubejob/releases/tag/v0.2.14

- Support TerminationLog api
- Confirm containers status correctly