### PR TITLE
Fix checkout logic to avoid missing files

### DIFF
--- a/api/v1/repo_test.go
+++ b/api/v1/repo_test.go
@@ -2,10 +2,21 @@ package v1
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/sosedoff/gitkit"
 )
 
 func TestRepositoryManager(t *testing.T) {
@@ -105,4 +116,163 @@ func TestRepositoryManager(t *testing.T) {
 		}
 		t.Logf("archive path: %s", path)
 	})
+	t.Run("add a file that specified to be ignored on the base branch", func(t *testing.T) {
+		addr, reposDir := runGitServer(t)
+
+		// create test repository
+		repoName := "test"
+		fs := osfs.New(filepath.Join(reposDir, repoName))
+		storage := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		repo, err := git.Init(storage, fs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w, err := repo.Worktree()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// create .gitignore
+		f, err := fs.Create(".gitignore")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if _, err := f.Write([]byte("*.txt")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Add(".gitignore"); err != nil {
+			t.Fatal(err)
+		}
+
+		// commit1
+		commit1, err := w.Commit("commit1", &git.CommitOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// update .gitignore
+		f, err = fs.OpenFile(".gitignore", os.O_RDWR|os.O_APPEND, 0o666)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write([]byte("\n!test.txt")); err != nil {
+			t.Fatal(err)
+		}
+
+		// create test.txt
+		f, err = fs.Create("test.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if _, err := f.Write([]byte("test")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Add("test.txt"); err != nil {
+			t.Fatal(err)
+		}
+
+		// commit2
+		commit2, err := w.Commit("commit2", &git.CommitOptions{All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// set refs/heads/master => commit1
+		master := plumbing.NewHashReference("refs/heads/master", commit1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.Storer.SetReference(master); err != nil {
+			t.Fatal(err)
+		}
+
+		// set refs/heads/feature => commit2
+		feature := plumbing.NewHashReference("refs/heads/feature", commit2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.Storer.SetReference(feature); err != nil {
+			t.Fatal(err)
+		}
+
+		// clone by RepositoryManager
+		repoDir := filepath.Join(t.TempDir(), repoName)
+		spec := RepositorySpec{
+			Name: repoName,
+			Value: Repository{
+				URL: fmt.Sprintf("http://%s/%s", addr, repoName),
+				Rev: feature.Hash().String(),
+				Merge: &MergeSpec{
+					Base: "master",
+				},
+				ClonedPath: repoDir,
+			},
+		}
+		if err := NewValidator().ValidateRepositorySpec(spec); err != nil {
+			t.Fatal(err)
+		}
+		mgr := NewRepositoryManager([]RepositorySpec{spec}, new(TokenManager))
+		t.Cleanup(func() {
+			mgr.Cleanup()
+		})
+		if err := mgr.CloneAll(WithLogger(context.Background(), NewLogger(os.Stdout, LogLevelDebug))); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err = git.PlainOpen(repoDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w, err = repo.Worktree()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertFile(t, w.Filesystem, ".gitignore", "*.txt\n!test.txt")
+		assertFile(t, w.Filesystem, "test.txt", "test")
+	})
+}
+
+func runGitServer(t *testing.T) (string, string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	h := gitkit.New(gitkit.Config{
+		Dir: tempDir,
+	})
+	if err := h.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	srv := &http.Server{
+		Handler: h,
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+	t.Cleanup(func() {
+		_ = srv.Close()
+	})
+
+	return ln.Addr().String(), tempDir
+}
+
+func assertFile(t *testing.T, fs billy.Filesystem, path string, expect string) {
+	t.Helper()
+
+	f, err := fs.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(b); got != expect {
+		t.Errorf("%s: expect %q but got %q", path, expect, got)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4
+	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
 	github.com/goccy/kubejob v0.3.2
@@ -12,6 +13,7 @@ require (
 	github.com/lestrrat-go/backoff v1.0.1
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0
+	github.com/sosedoff/gitkit v0.3.0
 	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/tools v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/goccy/go-json v0.9.7 h1:IcB+Aqpx/iMHu5Yooh7jEzJk1JZ7Pjtmys2ukPr7EeM=
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/kubejob v0.3.2 h1:zCpu/FTmwZjmaRBThOsQK7WyWMJxnF497yLSoy3ajHw=
 github.com/goccy/kubejob v0.3.2/go.mod h1:0i5F+s9kiuLsKkNFqccngdJ6i2N5H/L6pNoq/Qq97lk=
+github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
+github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -449,6 +451,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sosedoff/gitkit v0.3.0 h1:TfINVRNUM+GcFa+LGhZ3RcWN86Im1M6i8qs0IsgMy90=
+github.com/sosedoff/gitkit v0.3.0/go.mod h1:V3EpGZ0nvCBhXerPsbDeqtyReNb48cwP9KtkUYTKT5I=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -520,6 +524,7 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE8+RX+uXZyGhUy/ksMGJoc=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=


### PR DESCRIPTION
Test processes can't find some files because kubetest fails to restore files of the commit into the working tree. It seems to be caused by the behavior of go-git concerned with `.gitignore`.

### how to reproduce

1. Add a pattern to `.gitignore` on the base branch.
```.gitignore
# .gitignore
*.txt
```

2. Add a new file matching the pattern and exclude it on the test target branch.
```sh
$ touch test.txt
```
```.gitignore
# .gitignore
*.txt
!test.txt
```

3. Run kubetest with the merge spec.
```yaml
repos:
  - name: test-repo
    value:
      url: <repo-url>
      rev: <target-commit-revision>
      merge:
        base: <base-branch>
```