### PR TITLE
Support finalizer

### DIFF
--- a/api/v1/runner_test.go
+++ b/api/v1/runner_test.go
@@ -138,6 +138,53 @@ func TestRunner(t *testing.T) {
 			})
 		}
 	})
+	t.Run("finalizerContainer", func(t *testing.T) {
+		for _, runMode := range getRunModes() {
+			t.Run(runMode.String(), func(t *testing.T) {
+				runner := NewRunner(getConfig(), runMode)
+				runner.SetLogger(NewLogger(os.Stdout, LogLevelDebug))
+				if _, err := runner.Run(context.Background(), TestJob{
+					ObjectMeta: testjobObjectMeta(),
+					Spec: TestJobSpec{
+						Repos: testRepos(),
+						MainStep: MainStep{
+							Template: TestJobTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									GenerateName: "test",
+								},
+								Spec: TestJobPodSpec{
+									Containers: []TestJobContainer{
+										{
+											Container: corev1.Container{
+												Name:         "test",
+												Image:        "alpine",
+												Command:      []string{"echo"},
+												Args:         []string{"hello"},
+												WorkingDir:   filepath.Join("/", "work"),
+												VolumeMounts: []corev1.VolumeMount{testRepoVolumeMount()},
+											},
+										},
+									},
+									FinalizerContainer: TestJobContainer{
+										Container: corev1.Container{
+											Name:    "finalizer",
+											Image:   "alpine",
+											Command: []string{"echo"},
+											Args:    []string{"finalizer"},
+										},
+									},
+									Volumes: []TestJobVolume{testRepoVolume()},
+								},
+							},
+						},
+					},
+				}); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
+	})
+
 	t.Run("use token", func(t *testing.T) {
 		if !inCluster {
 			privateKeyPath := filepath.Join("..", "..", "testdata", "githubapp.private-key.pem")
@@ -670,7 +717,7 @@ func TestRunner(t *testing.T) {
 										Dynamic: &StrategyDynamicKeySource{
 											Template: TestJobTemplateSpec{
 												ObjectMeta: metav1.ObjectMeta{
-													Name: "list",
+													GenerateName: "list-",
 												},
 												Spec: TestJobPodSpec{
 													Containers: []TestJobContainer{
@@ -736,7 +783,7 @@ func TestRunner(t *testing.T) {
 										Dynamic: &StrategyDynamicKeySource{
 											Template: TestJobTemplateSpec{
 												ObjectMeta: metav1.ObjectMeta{
-													Name: "list",
+													GenerateName: "list-",
 												},
 												Spec: TestJobPodSpec{
 													Containers: []TestJobContainer{
@@ -771,7 +818,7 @@ func TestRunner(t *testing.T) {
 							},
 							Template: TestJobTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Name: "test",
+									GenerateName: "test-",
 								},
 								Spec: TestJobPodSpec{
 									Containers: []TestJobContainer{
@@ -831,7 +878,7 @@ func TestRunner(t *testing.T) {
 							},
 							Template: TestJobTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Name: "test",
+									GenerateName: "test-",
 								},
 								Spec: TestJobPodSpec{
 									Artifacts: []ArtifactSpec{
@@ -913,7 +960,7 @@ func TestRunner(t *testing.T) {
 							},
 							Template: TestJobTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Name: "test",
+									GenerateName: "test-",
 								},
 								Spec: TestJobPodSpec{
 									Artifacts: []ArtifactSpec{
@@ -944,7 +991,7 @@ func TestRunner(t *testing.T) {
 								Name: "post-step",
 								Template: TestJobTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Name: "post",
+										GenerateName: "post-",
 									},
 									Spec: TestJobPodSpec{
 										Containers: []TestJobContainer{
@@ -1044,7 +1091,7 @@ func TestRunner(t *testing.T) {
 							},
 							Template: TestJobTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Name: "test",
+									GenerateName: "test-",
 								},
 								Spec: TestJobPodSpec{
 									Artifacts: []ArtifactSpec{
@@ -1140,7 +1187,7 @@ func TestRunner(t *testing.T) {
 							},
 							Template: TestJobTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Name: "test",
+									GenerateName: "test-",
 								},
 								Main: "test",
 								Spec: TestJobPodSpec{

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -161,11 +161,12 @@ type TestJobTemplateSpec struct {
 
 // TestJobPodSpec
 type TestJobPodSpec struct {
-	corev1.PodSpec `json:",inline"`
-	InitContainers []TestJobContainer `json:"initContainers,omitempty"`
-	Containers     []TestJobContainer `json:"containers"`
-	Volumes        []TestJobVolume    `json:"volumes,omitempty"`
-	Artifacts      []ArtifactSpec     `json:"artifacts,omitempty"`
+	corev1.PodSpec     `json:",inline"`
+	InitContainers     []TestJobContainer `json:"initContainers,omitempty"`
+	Containers         []TestJobContainer `json:"containers"`
+	FinalizerContainer TestJobContainer   `json:"finalizerContainer"`
+	Volumes            []TestJobVolume    `json:"volumes,omitempty"`
+	Artifacts          []ArtifactSpec     `json:"artifacts,omitempty"`
 }
 
 // TestAgentSpec describes the specification of kubetest-agent.

--- a/api/v1/validator.go
+++ b/api/v1/validator.go
@@ -225,6 +225,11 @@ func (v *Validator) ValidateTestJobPodSpec(spec TestJobPodSpec, stepType StepTyp
 			return err
 		}
 	}
+	if spec.FinalizerContainer.Name != "" {
+		if err := v.ValidateTestJobContainer(spec.FinalizerContainer); err != nil {
+			return err
+		}
+	}
 	for _, volume := range spec.Volumes {
 		if err := v.ValidateTestJobVolume(volume, stepType); err != nil {
 			return err
@@ -254,10 +259,10 @@ func (v *Validator) ValidateTestJobPodSpec(spec TestJobPodSpec, stepType StepTyp
 
 func (v *Validator) ValidateTestJobContainer(container TestJobContainer) error {
 	if len(container.Command) == 0 {
-		return fmt.Errorf("kubetest: template.spec.initContainers[].command must be specified")
+		return fmt.Errorf("kubetest: container's command must be specified")
 	}
 	if container.Image == "" {
-		return fmt.Errorf("kubetest: template.spec.initContainers[].image must be specified")
+		return fmt.Errorf("kubetest: container's image must be specified")
 	}
 	if container.Agent != nil {
 		return v.ValidateTestAgentSpec(container.Agent)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.8.1
 	github.com/go-logr/logr v1.2.4
-	github.com/goccy/kubejob v0.4.0
+	github.com/goccy/kubejob v0.4.1-0.20230828064447-fe0693bed645
 	github.com/google/go-github/v54 v54.0.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/lestrrat-go/backoff v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
-github.com/goccy/kubejob v0.4.0 h1:SGZ/u12zzamGHJXXk38Z+24wnAW7NQwQbHn7qQzAQlM=
-github.com/goccy/kubejob v0.4.0/go.mod h1:Gsha9Njml/hrkQK224eVdwwwY5C1F8aEwjRbQyJf0fg=
+github.com/goccy/kubejob v0.4.1-0.20230828064447-fe0693bed645 h1:r40Mr2CxDaDrY+MPVZMfG6fBlzJ/YanpVnFFPdQPe4g=
+github.com/goccy/kubejob v0.4.1-0.20230828064447-fe0693bed645/go.mod h1:Gsha9Njml/hrkQK224eVdwwwY5C1F8aEwjRbQyJf0fg=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=


### PR DESCRIPTION
Support `finalizerContainer` in `TestJobPodSpec` for termination of injected container.
Command of `finalizerContainer` executed after all container's command finished .


```yaml
  mainStep:
    template:
      metadata:
        generateName: testjob-
      spec:
        containers:
          - name: test
            image: alpine
            workingDir: /work
            command:
              - ls
            args:
              - README.md
        finalizerContainer:
          name: finalizer
          image: alpine
          command:
            - echo
          args:
            - "finish"
```